### PR TITLE
github: use OIDC for AWS auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   amd:
+    permissions:
+      id-token: write # This is required for requesting the OIDC Token
+      contents: read
     name: Amd release build
     runs-on: ubuntu-latest
     steps:
@@ -53,17 +56,19 @@ jobs:
         run: mkdir lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }} && cp ~/go/bin/litd lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }}/litd && cp ~/go/bin/litcli lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }}/litcli && tar -zcvf lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }}.tar.gz lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }} 
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
           aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-litd
 
       - name: Upload build to S3
         run: |
           aws s3 cp lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }}.tar.gz s3://lnd-prod-artifacts/builds/lightning-terminal/${{ env.RELEASE_VERSION }}/lightning-terminal-linux-amd64-${{ env.RELEASE_VERSION }}.tar.gz --acl=public-read
 
   arm:
+    permissions:
+      id-token: write # This is required for requesting the OIDC Token
+      contents: read
     name: Arm release build
     runs-on: ubuntu-latest
     steps:
@@ -97,17 +102,19 @@ jobs:
         run: mkdir lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }} && cp ~/go/bin/linux_arm64/litd lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }}/litd && cp ~/go/bin/linux_arm64/litcli lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }}/litcli && tar -zcvf lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }}.tar.gz lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }} 
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
           aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-litd
 
       - name: Upload build to S3
         run: |
           aws s3 cp lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }}.tar.gz s3://lnd-prod-artifacts/builds/lightning-terminal/${{ env.RELEASE_VERSION }}/lightning-terminal-linux-arm64-${{ env.RELEASE_VERSION }}.tar.gz --acl=public-read
 
   darwin:
+    permissions:
+      id-token: write # This is required for requesting the OIDC Token
+      contents: read
     name: Darwin release build
     runs-on: ubuntu-latest
     steps:
@@ -141,11 +148,10 @@ jobs:
         run: mkdir lightning-terminal-darwin-arm64-${{ env.RELEASE_VERSION }} && cp ~/go/bin/darwin_arm64/litd lightning-terminal-darwin-arm64-${{ env.RELEASE_VERSION }}/litd && cp ~/go/bin/darwin_arm64/litcli lightning-terminal-darwin-arm64-${{ env.RELEASE_VERSION }}/litcli && tar -zcvf lightning-terminal-darwin-arm64-${{ env.RELEASE_VERSION }}.tar.gz lightning-terminal-darwin-arm64-${{ env.RELEASE_VERSION }} 
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY }}
           aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-litd
 
       - name: Upload build to S3
         run: |


### PR DESCRIPTION
Remove long-lived static credentials from our Github Actions workflows. Instead, use the OIDC role `github-litd` that allows pushing to ECR and writing to SSM.

Bump `configure-aws-credentials` to v2, as specified in this Github doc:
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#updating-your-github-actions-workflow